### PR TITLE
Feat: Stream Videos from UC Volumes into a Databricks App using FastAPI

### DIFF
--- a/docs/docs/fastapi/building_endpoints/volumes_stream_video.mdx
+++ b/docs/docs/fastapi/building_endpoints/volumes_stream_video.mdx
@@ -99,7 +99,6 @@ async def stream_video_files_api(request: Request):
         encoded_path = quote(file_path, safe="/")
         
         # Files API download endpoint: GET /api/2.0/fs/files{file_path}
-        # According to Databricks docs: https://docs.databricks.com/api/workspace/files/download
         url = f"https://{databricks_host}/api/2.0/fs/files{encoded_path}"
         
         logger.info(f"Streaming from Files API URL: {url}")


### PR DESCRIPTION
## Description

Adds documentation for streaming video files from Unity Catalog volumes in FastAPI applications.

## Motivation

Multiple customers have been working on video streaming use cases from UC volumes but are struggling without proper code examples. This PR provides a complete, production-ready code snippet that demonstrates how to:

- Authenticate using OAuth 2.0 client credentials flow
- Stream video files from Unity Catalog volumes using the Databricks Files API
- Support range requests for video seeking and progressive loading
- Handle chunked streaming for efficient memory usage
- Validate responses to catch authentication issues early

## Changes

- Added new documentation page: `docs/docs/fastapi/building_endpoints/volumes_stream_video.mdx`
- Included complete code snippet with OAuth token generation and video streaming endpoint
- Documented required environment variables, permissions, and dependencies
- Followed existing FastAPI documentation format and style

## Testing

Documentation follows the established pattern from other FastAPI endpoint examples in the cookbook.

## Related Resources

- [Databricks Files API](https://docs.databricks.com/api/workspace/files)
- [Unity Catalog Volumes](https://docs.databricks.com/en/volumes/index.html)