### PR TITLE
Change permission requirement from 'READ FILES' to 'READ VOLUME'

### DIFF
--- a/docs/docs/fastapi/building_endpoints/volumes_stream_video.mdx
+++ b/docs/docs/fastapi/building_endpoints/volumes_stream_video.mdx
@@ -201,7 +201,7 @@ The following environment variables must be set in your app configuration:
 
 Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/#how-does-databricks-apps-manage-authorization) needs the following permissions:
 
-- `READ FILES` privilege on the Unity Catalog volume containing the video file
+- `READ VOLUME` privilege on the Unity Catalog volume containing the video file
 
 See [Unity Catalog privileges and securable objects](https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges) for more information.
 


### PR DESCRIPTION
**Description:**


Fix the privilege name in the doc that gives read access to the app's sp to stream videos from UC volumes from `READ FILES` to `READ VOLUME`.