### PR TITLE
Add llms.txt and .md variants for LLM-friendly docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -67,6 +67,17 @@ const config: Config = {
         ],
       },
     ],
+    [
+      "docusaurus-plugin-llms",
+      {
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        generateMarkdownFiles: true,
+        preserveDirectoryStructure: true,
+        excludeImports: true,
+        removeDuplicateHeadings: true,
+      },
+    ],
   ],
 
   themeConfig: {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -29,6 +29,7 @@
         "@docusaurus/tsconfig": "^3.9.2",
         "@docusaurus/types": "^3.9.2",
         "@tailwindcss/postcss": "^4.1.11",
+        "docusaurus-plugin-llms": "^0.3.0",
         "postcss": "^8.5.6",
         "prettier": "^3.5.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
@@ -9314,6 +9315,50 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.3.0.tgz",
+      "integrity": "sha512-JuADAJA2fjTv1U4XQUoIu1LyjISDzxFhRK5HbCZiHum4HlmdPwyx8NBXsi+LfdUyjK9acbZgazGsHPhdwEZs0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "minimatch": "^9.0.3",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/dom-converter": {
@@ -21481,6 +21526,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && node scripts/fix-llms-md.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "wrangler deploy",
     "deploy:preview": "wrangler deploy --dry-run",
@@ -38,6 +38,7 @@
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.9.2",
     "@tailwindcss/postcss": "^4.1.11",
+    "docusaurus-plugin-llms": "^0.3.0",
     "postcss": "^8.5.6",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",

--- a/docs/scripts/fix-llms-md.mjs
+++ b/docs/scripts/fix-llms-md.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+/**
+ * fix-llms-md.mjs — Post-build fixups for docusaurus-plugin-llms output.
+ *
+ * 1. Duplicate headings in .md files
+ *    The plugin wraps each .md file with its own "# Title\n\n> Description"
+ *    preamble, but the source MDX already starts with the same "# Title",
+ *    producing a doubled heading. This script strips the plugin preamble when
+ *    the heading is duplicated.
+ *
+ *    Alternatives considered:
+ *     - Move headings into front matter `title:` across all MDX files (too invasive).
+ *     - Patch the plugin or fork it (maintenance burden).
+ *     - Accept duplicates (functional but looks sloppy).
+ *
+ * 2. Double-slash in llms.txt / llms-full.txt URLs
+ *    The plugin constructs URLs as `siteConfig.url + baseUrl + path`. When
+ *    baseUrl is "/" (root), this produces "https://example.dev//docs/..."
+ *    instead of a single slash. Browsers normalize this, but it's cosmetically
+ *    wrong and could confuse strict URL parsers.
+ *
+ *    Alternatives considered:
+ *     - Plugin pathTransformation option (doesn't affect base URL joining).
+ *     - Upstream fix (correct but not in our control; see github.com/rachfop/docusaurus-plugin-llms/issues/27).
+ *     - Accept double-slash (functional but ugly).
+ *
+ * 3. Truncated descriptions in llms.txt
+ *    The plugin hardcodes a 150-character limit on link descriptions
+ *    (cleanDescriptionForToc in generator.js), cutting them mid-sentence.
+ *    This script re-derives full first-paragraph descriptions from the
+ *    generated .md files.
+ *
+ *    Alternatives considered:
+ *     - Patch the 150-char limit via postinstall (fragile across upgrades).
+ *     - File upstream issue for configurable descriptionMaxLength (not in our control).
+ *     - Drop descriptions entirely (Stripe does this; agents fetch .md anyway).
+ *
+ * Execution order matters: Fix 1 (dedup headings in .md files) runs first so
+ * that Fix 3 (descriptions) reads clean .md content when deriving paragraphs.
+ *
+ * Run after `docusaurus build`: see "build" script in package.json.
+ */
+
+import { readFileSync, writeFileSync, globSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const buildDir = resolve(__dirname, "..", "build");
+const buildDocsDir = resolve(buildDir, "docs");
+
+// --- Fix 1: Duplicate headings in individual .md files ---
+
+function fixDuplicateHeading(filePath) {
+  const text = readFileSync(filePath, "utf-8");
+  const lines = text.split("\n");
+
+  // Expect: line 0 = "# Title", line 1 = "", line 2 = "> ...", line 3 = "", line 4 = "# Title"
+  if (lines.length < 5) return;
+
+  const firstHeading = lines[0];
+  if (!firstHeading.startsWith("# ")) return;
+
+  const blockquote = lines[2];
+  if (!blockquote.startsWith("> ")) return;
+
+  const secondHeading = lines[4];
+  if (firstHeading !== secondHeading) return;
+
+  const fixed = lines.slice(4).join("\n");
+  writeFileSync(filePath, fixed);
+}
+
+// --- Fix 2: Double-slash in llms.txt / llms-full.txt URLs ---
+
+function fixDoubleSlashUrls(text) {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/(?<=https?:\/\/[^/]+)\/\//g, "/"))
+    .join("\n");
+}
+
+// --- Fix 3: Restore full descriptions in llms.txt from .md files ---
+
+const LINK_LINE_RE = /^- \[([^\]]+)\]\(([^)]+)\)(?::.*)?$/;
+
+function extractFirstParagraph(mdPath) {
+  let text;
+  try {
+    text = readFileSync(mdPath, "utf-8");
+  } catch {
+    return undefined;
+  }
+  const lines = text.split("\n");
+  // Skip heading and blank line: "# Title\n\n<paragraph>"
+  let start = 0;
+  if (lines[start]?.startsWith("# ")) start++;
+  while (start < lines.length && lines[start].trim() === "") start++;
+
+  const para = [];
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "" && para.length > 0) break;
+    // Stop at subheadings, fences, admonitions — first paragraph only.
+    if (/^#{2,}\s|^```|^:::/.test(line)) break;
+    para.push(line.trim());
+  }
+  return para.length > 0 ? para.join(" ") : undefined;
+}
+
+// 4. Framework prefix in llms.txt titles
+//    The same recipe appears under each framework (dash, streamlit, reflex,
+//    fastapi) with identical titles. Without disambiguation, llms.txt has
+//    four "Connect an MCP server" entries that only differ by URL path.
+//    This prefixes each title with the framework name (e.g., "Dash: Connect
+//    an MCP server"). Only known frameworks are prefixed; new top-level
+//    sections would need to be added here.
+//
+//    Alternatives considered:
+//     - Parentheses suffix "(Dash)" — conflicts with Markdown link syntax.
+//     - Group entries under ## Framework headers (cleaner but more complex).
+//     - Do nothing — URL paths already contain the framework name.
+const FRAMEWORK_LABELS = { dash: "Dash", fastapi: "FastAPI", reflex: "Reflex", streamlit: "Streamlit" };
+
+function fixDescriptions(text) {
+  return text
+    .split("\n")
+    .map((line) => {
+      const m = line.match(LINK_LINE_RE);
+      if (!m) return line;
+
+      const [, title, url] = m;
+      let urlPath;
+      try {
+        urlPath = new URL(url).pathname;
+      } catch {
+        return line;
+      }
+
+      const framework = urlPath.match(/^\/docs\/([^/]+)\//)?.[1];
+      const prefix = FRAMEWORK_LABELS[framework] ? `${FRAMEWORK_LABELS[framework]}: ` : "";
+
+      const mdPath = resolve(buildDir, urlPath.replace(/^\//, ""));
+      const desc = extractFirstParagraph(mdPath);
+      if (!desc) return line;
+      return `- [${prefix}${title}](${url}): ${desc}`;
+    })
+    .join("\n");
+}
+
+// --- Run ---
+
+// Fix 1 first: deduplicate .md headings so Fix 3 reads clean content.
+const mdFiles = globSync(`${buildDocsDir}/**/*.md`);
+for (const f of mdFiles) {
+  fixDuplicateHeading(f);
+}
+console.log(`[fix-llms-md] Deduplicated headings in ${mdFiles.length} .md files.`);
+
+// Fixes 2 + 3: patch llms.txt and llms-full.txt (URLs and descriptions).
+for (const name of ["llms.txt", "llms-full.txt"]) {
+  const filePath = resolve(buildDir, name);
+  try {
+    let text = readFileSync(filePath, "utf-8");
+    text = fixDoubleSlashUrls(text);
+    text = fixDescriptions(text);
+    writeFileSync(filePath, text);
+  } catch {
+    // File may not exist if the plugin option was disabled; skip silently.
+  }
+}
+console.log("[fix-llms-md] Fixed URLs and descriptions in llms*.txt.");


### PR DESCRIPTION
# PR description

## Summary

- Add [llms.txt](https://llmstxt.org/) support and `.md` companion files so AI agents can discover and consume the docs as Markdown.
- `llms.txt`, `llms-full.txt`, and `.md` companion files are generated at build time via [docusaurus-plugin-llms](https://github.com/rachfop/docusaurus-plugin-llms).
- A post-build script (`scripts/fix-llms-md.mjs`) cleans up plugin quirks: duplicate headings in `.md` files, double-slash URLs, truncated descriptions, and duplicate titles across frameworks. Rationale and alternatives are documented in the script. Typically the simplest path was chosen for this PR.
- Since each recipe appears under multiple frameworks with the same title, `llms.txt` entries are prefixed with the framework name (e.g., "Dash: Connect an MCP server"). New top-level doc sections would need to be added to `FRAMEWORK_LABELS` in the script.
- No changes to existing pages, routing, or deployment; build-time only.

### Potential follow-up

- A Cloudflare Worker could support `Accept: text/markdown` content negotiation and serve `llms.txt` at additional paths like `/docs/llms.txt`. Kept out of this PR to limit scope.
- Alternatively, Cloudflare's built-in [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) feature can convert HTML to Markdown on the fly and do content negotiation (Pro+ plan required), although it appears to include some nav, sidebar, and footer content.

## Test plan

- [ ] `cd docs && npm install && npm run build` succeeds
- [ ] `/llms.txt` returns a valid index with correct URLs, full descriptions, and framework-prefixed titles
- [ ] `.md` links from llms.txt return clean Markdown with single headings and no JSX remnants
- [ ] Existing HTML doc pages still render correctly
