### PR TITLE
Document bundle UC parent grants gap for volume recipes

### DIFF
--- a/dash/pages/volumes_download.py
+++ b/dash/pages/volumes_download.py
@@ -94,7 +94,29 @@ file_name = os.path.basename(download_file_path)
                                   href="https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations",
                                   target="_blank"),
                             " for more information."
-                        ])
+                        ]),
+                        html.P([
+                            "If you declare volume access in a Databricks Asset Bundle, ",
+                            html.Code("resources.apps[*].resources[*].uc_securable"),
+                            " may not grant ",
+                            html.Code("USE_CATALOG"),
+                            " and ",
+                            html.Code("USE_SCHEMA"),
+                            " on the parent catalog and schema (the app still needs them at runtime). ",
+                            "As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see ",
+                            html.A("apps_grants_sync",
+                                   href="https://github.com/salihbout/apps_grants_sync",
+                                   target="_blank"),
+                            ": an example Databricks App and Asset Bundle that wires ",
+                            html.Code("experimental.scripts.postdeploy"),
+                            " so parent privileges are applied after each ",
+                            html.Code("databricks bundle deploy"),
+                            " (copy its ",
+                            html.Code("tools/"),
+                            " into your bundle or mirror the same pattern in ",
+                            html.Code("databricks.yml"),
+                            ")."
+                        ], className="mb-0")
                     ]),
                     dbc.Col([
                         html.H4("Databricks resources", className="mb-3"),

--- a/dash/pages/volumes_upload.py
+++ b/dash/pages/volumes_upload.py
@@ -126,7 +126,29 @@ w.files.upload(volume_file_path, binary_data, overwrite=True)
                                   href="https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations",
                                   target="_blank"),
                             " for more information."
-                        ])
+                        ]),
+                        html.P([
+                            "If you declare volume access in a Databricks Asset Bundle, ",
+                            html.Code("resources.apps[*].resources[*].uc_securable"),
+                            " may not grant ",
+                            html.Code("USE_CATALOG"),
+                            " and ",
+                            html.Code("USE_SCHEMA"),
+                            " on the parent catalog and schema (the app still needs them at runtime). ",
+                            "As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see ",
+                            html.A("apps_grants_sync",
+                                   href="https://github.com/salihbout/apps_grants_sync",
+                                   target="_blank"),
+                            ": an example Databricks App and Asset Bundle that wires ",
+                            html.Code("experimental.scripts.postdeploy"),
+                            " so parent privileges are applied after each ",
+                            html.Code("databricks bundle deploy"),
+                            " (copy its ",
+                            html.Code("tools/"),
+                            " into your bundle or mirror the same pattern in ",
+                            html.Code("databricks.yml"),
+                            ")."
+                        ], className="mb-0")
                     ]),
                     dbc.Col([
                         html.H4("Databricks resources", className="mb-3"),

--- a/docs/docs/dash/volumes/volumes_download.mdx
+++ b/docs/docs/dash/volumes/volumes_download.mdx
@@ -39,6 +39,8 @@ Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databr
 
 See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
 
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
+
 ## Dependencies
 
 - [Databricks SDK for Python](https://pypi.org/project/databricks-sdk/) - `databricks-sdk`

--- a/docs/docs/dash/volumes/volumes_upload.mdx
+++ b/docs/docs/dash/volumes/volumes_upload.mdx
@@ -46,6 +46,8 @@ Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databr
 
 See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
 
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
+
 ## Dependencies
 
 - [Databricks SDK for Python](https://pypi.org/project/databricks-sdk/) - `databricks-sdk`

--- a/docs/docs/fastapi/building_endpoints/volumes_stream_video.mdx
+++ b/docs/docs/fastapi/building_endpoints/volumes_stream_video.mdx
@@ -205,6 +205,8 @@ Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databr
 
 See [Unity Catalog privileges and securable objects](https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges) for more information.
 
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
+
 ## Dependencies
 
 - [FastAPI](https://pypi.org/project/fastapi/) - `fastapi`

--- a/docs/docs/reflex/volumes/volumes_download.mdx
+++ b/docs/docs/reflex/volumes/volumes_download.mdx
@@ -46,6 +46,8 @@ Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databr
 
 See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
 
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
+
 ## Dependencies
 
 - [Databricks SDK for Python](https://pypi.org/project/databricks-sdk/) - `databricks-sdk`

--- a/docs/docs/reflex/volumes/volumes_upload.mdx
+++ b/docs/docs/reflex/volumes/volumes_upload.mdx
@@ -94,6 +94,8 @@ Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databr
 
 See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
 
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
+
 ## Dependencies
 
 - [Databricks SDK for Python](https://pypi.org/project/databricks-sdk/) - `databricks-sdk`

--- a/docs/docs/streamlit/volumes/volumes_download.mdx
+++ b/docs/docs/streamlit/volumes/volumes_download.mdx
@@ -46,6 +46,8 @@ Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databr
 
 See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
 
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
+
 ## Dependencies
 
 - [Databricks SDK for Python](https://pypi.org/project/databricks-sdk/) - `databricks-sdk`

--- a/docs/docs/streamlit/volumes/volumes_upload.mdx
+++ b/docs/docs/streamlit/volumes/volumes_upload.mdx
@@ -51,6 +51,8 @@ Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databr
 
 See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
 
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
+
 ## Dependencies
 
 - [Databricks SDK for Python](https://pypi.org/project/databricks-sdk/) - `databricks-sdk`

--- a/reflex/app/pages/download_file.py
+++ b/reflex/app/pages/download_file.py
@@ -41,6 +41,8 @@ def download_file_requirements() -> rx.Component:
 * `READ VOLUME` on the volume
 
 See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
+
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
 """,
                 class_name="text-sm text-gray-600",
             ),

--- a/reflex/app/pages/upload_file.py
+++ b/reflex/app/pages/upload_file.py
@@ -95,6 +95,8 @@ def upload_file_requirements() -> rx.Component:
 * `READ VOLUME` and `WRITE VOLUME` on the volume
 
 See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
+
+If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
 """,
                 class_name="text-sm text-gray-600",
             ),

--- a/streamlit/views/volumes_download.py
+++ b/streamlit/views/volumes_download.py
@@ -68,7 +68,9 @@ with tab3:
                     * `USE SCHEMA` on the volume's schema
                     * `READ VOLUME` on the volume
 
-                    See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information. 
+                    See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
+
+                    If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
 
                     """)
     with col2:

--- a/streamlit/views/volumes_upload.py
+++ b/streamlit/views/volumes_upload.py
@@ -130,7 +130,9 @@ with tab3:
                     * `USE SCHEMA` on the schema of the volume
                     * `READ VOLUME` and `WRITE VOLUME` on the volume
 
-                    See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information. 
+                    See [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations) for more information.
+
+                    If you declare volume access in a Databricks Asset Bundle, `resources.apps[*].resources[*].uc_securable` may not grant `USE_CATALOG` and `USE_SCHEMA` on the parent catalog and schema (the app still needs them at runtime). As a temporary workaround until bundles can declare those parent grants, add the privileges manually, or see [apps_grants_sync](https://github.com/salihbout/apps_grants_sync): an example Databricks App and Asset Bundle that wires `experimental.scripts.postdeploy` so parent privileges are applied after each `databricks bundle deploy` (copy its `tools/` into your bundle or mirror the same pattern in `databricks.yml`).
 
                     """)
     with col2:


### PR DESCRIPTION
**Summary**
Documents a known limitation when granting Unity Catalog volume access through Databricks Asset Bundles: resources.apps[*].resources[*].uc_securable may not apply USE_CATALOG / USE_SCHEMA on the parent catalog and schema, even though the app still needs those privileges at runtime.

Adds a short note that this is a temporary workaround gap until bundles can declare those parent grants, and points readers to [apps_grants_sync](https://github.com/salihbout/apps_grants_sync) as an example Databricks App and Asset Bundle that wires experimental.scripts.postdeploy to apply parent privileges after databricks bundle deploy, with guidance to copy its tools/ or mirror the same pattern in databricks.yml.

**Changes**
Dash — Requirements tab on volume upload/download pages
Streamlit — Requirements tab on volume upload/download views
Reflex — Requirements copy on upload/download file pages
Docs — Permissions sections in Dash / Streamlit / Reflex volume MDX pages and the FastAPI Stream video from volumes recipe

**Related**
UC volume privileges: [Privileges required for volume operations](https://docs.databricks.com/en/volumes/privileges.html#privileges-required-for-volume-operations)
Example bundle + post-deploy workaround: [salihbout/apps_grants_sync](https://github.com/salihbout/apps_grants_sync)