### PR TITLE
Upgrade lucide-react to 1.x; expand smoke to cover all pages

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -15,7 +15,7 @@
         "@sanity/client": "^7.22.0",
         "clsx": "^2.1.1",
         "docusaurus-lunr-search": "^3.6.0",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.14.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -12768,9 +12768,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://npm-proxy.dev.databricks.com/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.14.0",
+      "resolved": "https://npm-proxy.dev.databricks.com/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,7 +25,7 @@
     "@sanity/client": "^7.22.0",
     "clsx": "^2.1.1",
     "docusaurus-lunr-search": "^3.6.0",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.14.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/docs/scripts/smoke-test.mjs
+++ b/docs/scripts/smoke-test.mjs
@@ -21,8 +21,14 @@ import { createRequire } from "node:module";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DOCS_ROOT = resolve(__dirname, "..");
 const SRC_DIR = join(DOCS_ROOT, "src");
+const BUILD_DIR = join(DOCS_ROOT, "build");
 const PORT = Number(process.env.PORT || 4321);
-const PAGES_TO_RENDER = ["/", "/gallery/", "/gallery/pixels", "/resources"];
+// Fallback if the build directory hasn't been produced yet — keeps the smoke
+// test useful in CI configurations that skip the build.
+const FALLBACK_PAGES = ["/", "/gallery/", "/gallery/pixels", "/resources"];
+// Path segments that indicate a template route (e.g. /gallery/:id) which
+// docusaurus emits during build but which can't be visited directly.
+const TEMPLATE_SEGMENT = /:/;
 const BASE = `http://127.0.0.1:${PORT}`;
 const SERVE_START_TIMEOUT_MS = 60_000;
 
@@ -82,6 +88,48 @@ function auditLucideImports() {
     }
   }
   return missing;
+}
+
+// Enumerate every static route from the build output. Each generated route
+// lives at `build/<path>/index.html`. Falls back to a small hand-picked list
+// if the build hasn't been produced.
+function discoverPages() {
+  let stat;
+  try {
+    stat = statSync(BUILD_DIR);
+  } catch {
+    console.warn(
+      `Render check: ${BUILD_DIR} not found, using fallback page list.`,
+    );
+    return FALLBACK_PAGES;
+  }
+  if (!stat.isDirectory()) return FALLBACK_PAGES;
+
+  const pages = new Set();
+  const stack = [BUILD_DIR];
+  while (stack.length) {
+    const dir = stack.pop();
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const s = statSync(full);
+      if (s.isDirectory()) {
+        stack.push(full);
+      } else if (entry === "index.html") {
+        const rel = dir.slice(BUILD_DIR.length) || "/";
+        const route = (rel.endsWith("/") ? rel : rel + "/").replace(/^\/*/, "/");
+        if (TEMPLATE_SEGMENT.test(route)) continue; // skip /gallery/:id etc.
+        pages.add(route);
+      }
+    }
+  }
+  // Drop the docusaurus 404 page — visiting it directly always returns the
+  // error page, which would confuse the crash detector.
+  pages.delete("/404.html/");
+  // Union the fallback list so dynamic routes that only exist as templates
+  // (e.g. /gallery/:id is emitted but unvisitable; /gallery/pixels is a
+  // concrete instance of it) still get exercised.
+  for (const p of FALLBACK_PAGES) pages.add(p);
+  return [...pages].sort();
 }
 
 function findChrome() {
@@ -170,10 +218,12 @@ async function renderCheck() {
     process.exit(130);
   });
 
+  const pages = discoverPages();
+  console.log(`Render check: ${pages.length} pages to visit`);
   const failures = [];
   try {
     await waitForServer(`${BASE}/`, SERVE_START_TIMEOUT_MS);
-    for (const path of PAGES_TO_RENDER) {
+    for (const path of pages) {
       const url = `${BASE}${path}`;
       const html = renderDom(chrome, url);
       const crashed = /This page crashed|Minified React error/.test(html);

--- a/docs/src/components/GithubIcon.tsx
+++ b/docs/src/components/GithubIcon.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+// lucide-react 1.x dropped all brand icons, so we ship the GitHub mark
+// ourselves. Matches the lucide API surface we use (`size`, `className`).
+export default function GithubIcon({
+  size = 24,
+  className,
+}: {
+  size?: number | string;
+  className?: string;
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  );
+}

--- a/docs/src/pages/GalleryApp.tsx
+++ b/docs/src/pages/GalleryApp.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
 import Layout from "@theme/Layout";
 import { useLocation, useHistory } from "@docusaurus/router";
-import { ArrowLeft, Github } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
+import GithubIcon from "../components/GithubIcon";
 import { PortableText } from "@portabletext/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -433,7 +434,7 @@ function GalleryAppPage() {
               rel="noopener noreferrer"
               className="flex w-full flex-shrink-0 items-center justify-center gap-2 bg-lava-600 px-4 py-2 text-sm font-semibold whitespace-nowrap text-white! transition-colors hover:bg-lava-700 md:w-auto"
             >
-              <Github size={16} />
+              <GithubIcon size={16} />
               View Source
             </a>
           </div>

--- a/docs/src/pages/gallery.tsx
+++ b/docs/src/pages/gallery.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import Layout from "@theme/Layout";
-import { Github, BadgeCheck } from "lucide-react";
+import { BadgeCheck } from "lucide-react";
 import { useHistory, useLocation } from "@docusaurus/router";
 import FilterPills from "../components/FilterPills";
+import GithubIcon from "../components/GithubIcon";
 import { createClient } from "@sanity/client";
 import GalleryAppPage from "./GalleryApp";
 
@@ -488,7 +489,7 @@ function GalleryPage() {
                             title="View source"
                             onClick={(e) => e.stopPropagation()}
                           >
-                            <Github size={18} />
+                            <GithubIcon size={18} />
                             Source code
                           </a>
                         </div>


### PR DESCRIPTION
## Summary

Re-attempt of the v1 upgrade that PR #88 had to roll back. The blocker
was that `lucide-react@1` deliberately dropped all brand icons, so the
`Github` named import resolved to `undefined` and crashed `/gallery`
and `/gallery/:slug`.

- Replaced both `<Github />` call-sites with a local
  `docs/src/components/GithubIcon.tsx` — small SVG component matching
  lucide's `size` / `className` interface, so the JSX site stays a
  one-liner.
- Bumped `lucide-react` to `^1.14.0` and regenerated the lockfile.
- The two other icons we import (`BadgeCheck`, `ArrowLeft`) are still
  exported by v1; verified by the smoke audit step.

## Smoke test coverage

The smoke test from #88 hard-coded a 4-page render list. Replaced it
with build-output discovery: every `build/<route>/index.html` is now
visited (~90 pages today). The `/gallery/:id` template route is
skipped because it can't be visited directly, but the fallback list
keeps a concrete `/gallery/pixels` instance in the run so the
`GalleryApp` component (the second `<Github />` call-site) stays
exercised.

Locally:
- `npm run build` succeeds.
- `npm run smoke` with `CHROME_BIN=/usr/bin/google-chrome` passes
  90 / 90 render checks and the lucide audit.

## Test plan

- [ ] CI build + smoke pass on this PR.
- [ ] After deploy, https://apps-cookbook.dev/gallery loads and the
      cards show the GitHub icon next to "Source code".
- [ ] https://apps-cookbook.dev/gallery/pixels (and other detail pages)
      load and the "View Source" button still shows the icon.

This pull request and its description were written by Claude (claude-opus-4-7) under the direction of @jamesbroadhead.