### PR TITLE
Streamlit: Add a receipt for using H3 simply with streamlit

### DIFF
--- a/docs/docs/streamlit/visualizations/visualizations_map_h3.mdx
+++ b/docs/docs/streamlit/visualizations/visualizations_map_h3.mdx
@@ -59,7 +59,8 @@ shv.h3_choropleth(df, h3_col=h3_col)
 
 - [SQL warehouse](https://docs.databricks.com/aws/en/compute/sql-warehouse/) _(optional, only for reading table data)_
 - [Unity Catalog table](https://docs.databricks.com/aws/en/tables/) _(optional, only for reading table data)_
-- [H3 SQL reference] (https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-h3-geospatial-functions) _(optional, only for reading table data)_
+- [H3 SQL reference](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-h3-geospatial-functions) _(optional, only for reading table data)_
+- [H3](https://h3geo.org/) _(optional, only for reference to the concept H3)_
 
 ## Permissions
 

--- a/docs/docs/streamlit/visualizations/visualizations_map_h3.mdx
+++ b/docs/docs/streamlit/visualizations/visualizations_map_h3.mdx
@@ -1,0 +1,86 @@
+---
+sidebar_position: 3
+---
+
+# Map display with geo spatial index H3
+
+This recipe enables you to display geographic data on a map with H3
+
+## Code snippet
+
+### Display geo data from a table
+
+```python title="app.py"
+import streamlit as st
+import streamlit_hexviz as shv
+from databricks import sql
+from databricks.sdk.core import Config
+from databricks.sdk import WorkspaceClient
+import pandas as pd
+
+cfg = Config()
+w = WorkspaceClient()
+
+# List available SQL warehouses
+warehouses = w.warehouses.list()
+warehouse_paths = {wh.name: wh.odbc_params.path for wh in warehouses}
+
+# Connect to SQL warehouse
+def get_connection(http_path):
+    return sql.connect(
+        server_hostname=cfg.host,
+        http_path=http_path,
+        credentials_provider=lambda: cfg.authenticate,
+    )
+
+# Read table
+def read_table(table_name, conn):
+    with conn.cursor() as cursor:
+        cursor.execute(f"SELECT * FROM {table_name}")
+        return cursor.fetchall_arrow().to_pandas()
+
+# Get data and display on map
+warehouse_name = "your_warehouse_name"
+table_name = "samples.accuweather.forecast_daily_calendar_metric"
+
+http_path = warehouse_paths[warehouse_name]
+conn = get_connection(http_path)
+df = read_table(table_name, conn)
+
+# Display map with latitude/longitude columns
+shv.h3_map(df, lat="latitude", lon="longitude")
+
+# Display map in case table contains H3 index
+h3_col= 'your_h3_column_name'
+shv.h3_choropleth(df, h3_col=h3_col)
+```
+
+## Resources
+
+- [SQL warehouse](https://docs.databricks.com/aws/en/compute/sql-warehouse/) _(optional, only for reading table data)_
+- [Unity Catalog table](https://docs.databricks.com/aws/en/tables/) _(optional, only for reading table data)_
+- [H3 SQL reference] (https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-h3-geospatial-functions) _(optional, only for reading table data)_
+
+## Permissions
+
+Your [app service principal](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/#how-does-databricks-apps-manage-authorization) needs the following permissions:
+
+- `CAN USE` on the SQL warehouse _(only required if reading data from tables)_
+- `SELECT` on the Unity Catalog table _(only required if reading data from tables)_
+
+See Unity [Catalog privileges and securable objects](https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges) for more information.
+
+## Dependencies
+
+- [Streamlit](https://pypi.org/project/streamlit/) - `streamlit`
+- [Streamlit Hexviz](https://pypi.org/project/streamlit-hexviz/) - `streamlit-hexviz`
+- [Databricks SDK](https://pypi.org/project/databricks-sdk/) - `databricks-sdk` _(for table data)_
+- [Databricks SQL Connector](https://pypi.org/project/databricks-sql-connector/) - `databricks-sql-connector` _(for table data)_
+
+```python title="requirements.txt"
+streamlit
+streamlit-hexviz
+databricks-sdk
+databricks-sql-connector
+```
+

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -6,3 +6,4 @@ psycopg[binary]~=3.3
 streamlit~=1.56
 streamlit-folium~=0.27
 streamlit-hexviz~=0.2
+numpy

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -5,3 +5,4 @@ pandas~=3.0
 psycopg[binary]~=3.3
 streamlit~=1.56
 streamlit-folium~=0.27
+streamlit-hexviz~=0.2

--- a/streamlit/view_groups.py
+++ b/streamlit/view_groups.py
@@ -172,6 +172,12 @@ groups = [
                 "page": "views/visualizations_map.py",
                 "icon": ":material/globe:",
             },
+            {
+                "label": "Map display for H3",
+                "help": "Display geo information on a map with the geo spatial index H3.",
+                "page": "views/visualizations_map_h3.py",
+                "icon": ":material/globe:",
+            },
         ],
     },
     {

--- a/streamlit/views/visualizations_map_h3.py
+++ b/streamlit/views/visualizations_map_h3.py
@@ -2,15 +2,14 @@ import pandas as pd
 from databricks import sql
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.core import Config
-from folium.plugins import Draw
 import streamlit_hexviz as shv
 import streamlit as st
 import numpy as np
 
 st.header(body="Visualizations", divider=True)
-st.subheader("Map display and interaction")
+st.subheader("Map display with geo spatial index H3")
 st.write(
-    "This recipe enables you to display geographic data on a map and collect user geo input through interactive map drawing."
+    "This recipe enables you to display geographic data on a map with H3"
 )
 
 cfg = Config()
@@ -106,12 +105,12 @@ with tab_a:
                     conn = get_connection(http_path)
                     df = read_table(table_name, conn)
 
-                st.dataframe(df)
+                    st.dataframe(df)
 
-                try:
-                    shv.h3_choropleth(df, h3_col=h3_col)
-                except:
-                    st.warning('no H3 index found')
+                    try:
+                        shv.h3_choropleth(df, h3_col=h3_col)
+                    except:
+                        st.warning('no H3 index found')
     st.info('Streamlit-hexviz enables users to navigate through the different resolutions and change coloring with navigation in the sidebar')
 with tab_b:
     st.markdown("### Display geo data from a table")
@@ -154,10 +153,11 @@ conn = get_connection(http_path)
 df = read_table(table_name, conn)
 
 # Display map with latitude/longitude columns
-shv.map(df, lat="latitude", lon="longitude")
+shv.h3_map(df, lat="latitude", lon="longitude")
 
 
 # Display map in case table contains H3 index
+h3_col= 'your_h3_column_name'
 shv.h3_choropleth(df, h3_col=h3_col)
 
     """

--- a/streamlit/views/visualizations_map_h3.py
+++ b/streamlit/views/visualizations_map_h3.py
@@ -1,0 +1,196 @@
+import pandas as pd
+from databricks import sql
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.core import Config
+from folium.plugins import Draw
+import streamlit_hexviz as shv
+import streamlit as st
+import numpy as np
+
+st.header(body="Visualizations", divider=True)
+st.subheader("Map display and interaction")
+st.write(
+    "This recipe enables you to display geographic data on a map and collect user geo input through interactive map drawing."
+)
+
+cfg = Config()
+
+w = WorkspaceClient()
+
+warehouses = w.warehouses.list()
+
+warehouse_paths = {wh.name: wh.odbc_params.path for wh in warehouses}
+
+
+@st.cache_resource(ttl=300, show_spinner=True)
+def get_connection(http_path):
+    return sql.connect(
+        server_hostname=cfg.host,
+        http_path=http_path,
+        credentials_provider=lambda: cfg.authenticate,
+    )
+
+
+def read_table(table_name, conn):
+    with conn.cursor() as cursor:
+        query = f"SELECT * FROM {table_name}"
+        cursor.execute(query)
+        return cursor.fetchall_arrow().to_pandas()
+
+
+def make_london(n: int) -> pd.DataFrame:
+    """Simulate London bike hire density."""
+    rng = np.random.default_rng(7)
+    lats = rng.normal(51.505, 0.04, n)
+    lons = rng.normal(-0.12, 0.05, n)
+    duration = rng.exponential(1200, n)
+    return pd.DataFrame({"lat": lats, "lon": lons, "duration_s": duration})
+
+
+tab_a, tab_b, tab_c = st.tabs(
+    ["**Try it**", "**Code snippet**", "**Requirements**"])
+
+with tab_a:
+    # Sub-tabs for different functionalities
+    st.markdown("### Display data on a map")
+    st.write(
+        "Load a table from a Delta table and display the geographic data on a map."
+    )
+
+    display_option = st.radio(
+        "Choose data source:",
+        ["Sample data", "Load from a table", "Load from a table with H3 index"],
+        horizontal=True,
+    )
+
+    if display_option == "Sample data":
+        data = make_london(2000)
+        shv.h3_map(data, lat="lat", lon="lon")
+    else:
+        warehouse_selection = st.selectbox(
+            "Select a SQL Warehouse:",
+            options=[""] + list(warehouse_paths.keys()),
+            help="Warehouse list populated from your workspace using app service principal.",
+        )
+
+        table_name = st.text_input(
+            "Specify a Unity Catalog table name:",
+            value="samples.accuweather.forecast_daily_calendar_metric",
+            help="Use this example table or input your own",
+        )
+
+        if display_option == "Load from a table":
+            if warehouse_selection and table_name:
+                http_path = warehouse_paths[warehouse_selection]
+                conn = get_connection(http_path)
+                df = read_table(table_name, conn)
+
+                st.dataframe(df)
+
+                if "latitude" in df.columns and "longitude" in df.columns:
+                    df["latitude"] = pd.to_numeric(
+                        df["latitude"], errors="coerce")
+                    df["longitude"] = pd.to_numeric(
+                        df["longitude"], errors="coerce")
+                    df = df.dropna(subset=["latitude", "longitude"])
+
+                    if not df.empty:
+                        shv.h3_map(df, lat="latitude", lon="longitude")
+                else:
+                    st.warning("No longitude, latitude found in the table")
+        else:
+            h3_col = st.text_input('Specify H3 index')
+            if h3_col:
+                if warehouse_selection and table_name:
+                    http_path = warehouse_paths[warehouse_selection]
+                    conn = get_connection(http_path)
+                    df = read_table(table_name, conn)
+
+                st.dataframe(df)
+
+                try:
+                    shv.h3_choropleth(df, h3_col=h3_col)
+                except:
+                    st.warning('no H3 index found')
+    st.info('Streamlit-hexviz enables users to navigate through the different resolutions and change coloring with navigation in the sidebar')
+with tab_b:
+    st.markdown("### Display geo data from a table")
+    st.code(
+        """
+import streamlit as st
+import streamlit_hexviz as shv
+from databricks import sql
+from databricks.sdk.core import Config
+from databricks.sdk import WorkspaceClient
+import pandas as pd
+
+cfg = Config()
+w = WorkspaceClient()
+
+# List available SQL warehouses
+warehouses = w.warehouses.list()
+warehouse_paths = {wh.name: wh.odbc_params.path for wh in warehouses}
+
+# Connect to SQL warehouse
+def get_connection(http_path):
+    return sql.connect(
+        server_hostname=cfg.host,
+        http_path=http_path,
+        credentials_provider=lambda: cfg.authenticate,
+    )
+
+# Read table
+def read_table(table_name, conn):
+    with conn.cursor() as cursor:
+        cursor.execute(f"SELECT * FROM {table_name}")
+        return cursor.fetchall_arrow().to_pandas()
+
+# Get data and display on map
+warehouse_name = "your_warehouse_name"
+table_name = "samples.accuweather.forecast_daily_calendar_metric"
+
+http_path = warehouse_paths[warehouse_name]
+conn = get_connection(http_path)
+df = read_table(table_name, conn)
+
+# Display map with latitude/longitude columns
+shv.map(df, lat="latitude", lon="longitude")
+
+
+# Display map in case table contains H3 index
+shv.h3_choropleth(df, h3_col=h3_col)
+
+    """
+    )
+
+with tab_c:
+    col1, col2, col3 = st.columns(3)
+
+    with col1:
+        st.markdown(
+            """
+                    **Permissions (app service principal)**
+                    * `CAN USE` on the SQL warehouse
+                    * `SELECT` on the Unity Catalog table
+                    
+                    _Note: Only required if reading data from tables_
+                    """
+        )
+    with col2:
+        st.markdown(
+            """
+                    **Databricks resources**
+                    * SQL warehouse _(optional, only for reading table data)_
+                    * Unity Catalog table _(optional, only for reading table data)_
+                    """
+        )
+    with col3:
+        st.markdown(
+            """
+                    **Dependencies**
+                    * [Streamlit](https://pypi.org/project/streamlit/) - `streamlit`
+                    * [Streamlit Hexviz](https://pypi.org/project/streamlit-hexviz/) - `streamlit-hexviz`
+                    * [Databricks SDK](https://pypi.org/project/databricks-sdk/) - `databricks-sdk` _(for table data)_
+                    * [Databricks SQL Connector](https://pypi.org/project/databricks-sql-connector/) - `databricks-sql-connector` _(for table data)_
+                    """
+        )


### PR DESCRIPTION
Hi,

Added a receipt for displaying geo data - in particular with the geo spatial index H3  and the dedicated streamlit component streamlit_hexviz. 

The component enables to load geo point (lon/lat) into a map, and provides a great and simple user interface to navigate into the data with a navigation.
The component also enables the push of h3 indexes into the map natively and then displays the data on the map. This is particularly useful, when the aggregation of the geo data is done in the database before. 

`
SELECT h3_longlatash3(longitudeExpr, latitudeExpr, resolutionExpr), count(*) as event_count, sum(values) as metric FROM my_table
group by 1
`

with this combination, very large geo data sets can be displayed smoothly in streamlit. 

This particular use case of having millions of events, needing fast aggregations lead to the building of the streamlit-hexviz package (which I maintain). 